### PR TITLE
Copying API keys to clipboard (resolves #37)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1217,6 +1217,16 @@
         }
       }
     },
+    "clipboard": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.7.1.tgz",
+      "integrity": "sha1-Ng1taUbpmnof7zleQrqStem1oWs=",
+      "requires": {
+        "good-listener": "1.2.2",
+        "select": "1.1.2",
+        "tiny-emitter": "2.0.2"
+      }
+    },
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -1525,6 +1535,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "delegate": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.1.3.tgz",
+      "integrity": "sha1-moJRp3fXAl+qVXN7w7BxdCEnqf0="
     },
     "delegates": {
       "version": "1.0.0",
@@ -2741,6 +2756,14 @@
           "integrity": "sha1-0iyaxmAojzhD4Wun0rXQbMon13c=",
           "dev": true
         }
+      }
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "requires": {
+        "delegate": "3.1.3"
       }
     },
     "graceful-fs": {
@@ -4462,6 +4485,11 @@
         }
       }
     },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
+    },
     "semver": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -4686,6 +4714,11 @@
         "fstream": "1.0.11",
         "inherits": "2.0.3"
       }
+    },
+    "tiny-emitter": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
+      "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow=="
     },
     "to-fast-properties": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "repository": {},
   "dependencies": {
     "babel-polyfill": "~6.26.0",
+    "clipboard": "^1.7.1",
     "concise-ui": "~0.2.1",
     "concise.css": "~4.1.2",
     "phoenix": "file:deps/phoenix",

--- a/web/static/frontend/js/machine_page.js
+++ b/web/static/frontend/js/machine_page.js
@@ -1,11 +1,27 @@
 /**
- * Code to execute on machines page. Adds prompt for deleting machines.
+ * Code to execute on machines page.
+ * 
+ * - Enables clipboard.js for "Copy" buttons
+ * - Makes API key inputs select all text on click
+ * - Adds prompt for deleting machines
  */
 
-function machine_page() {
-  document.addEventListener('DOMContentLoaded', () => {
-    const buttons = document.getElementsByClassName('machine-delete-button');
+import Clipboard from 'clipboard';
 
+function machine_page() {
+  const clipboard = new Clipboard('.copy-to-clipboard');
+  clipboard.on('success', (event) => {
+    event.trigger.innerText = 'Copied!';
+    event.clearSelection();
+  });
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const apiKeys = document.getElementsByClassName('api-key');
+    for (const input of apiKeys) {
+      input.onclick = (event) => event.target.select();
+    }
+
+    const buttons = document.getElementsByClassName('machine-delete-button');
     for (const button of buttons) {
       button.onclick = () => {
         return confirm('Are you sure you wish to delete this machine? You will lose all XP associated with it.');

--- a/web/templates/machine/machines.html.eex
+++ b/web/templates/machine/machines.html.eex
@@ -6,7 +6,10 @@
       <div class="col-xs-12">
         <h4><%= machine.name %></h4>
         <p>
-          API key: <code><%= CodeStats.AuthUtils.get_api_key(@conn, @user, machine) %></code>
+          API key:
+          <input id="api-key-<%= machine.id %>" class="api-key" readonly
+            value="<%= CodeStats.AuthUtils.get_api_key(@conn, @user, machine) %>" />
+          <button class="copy-to-clipboard" data-clipboard-target="#api-key-<%= machine.id %>">Copy</button>
         </p>
 
         <div class="pull-left machine-action">


### PR DESCRIPTION
Add clipboard.js based "Copy" buttons next to API keys. Change the API
key element to a readonly input, which is auto-selected on click.

I tried to follow the existing code style. Some things I considered but skipped:

- The key could be copied on click to the input, but that's intrusive.
- It would be easy to check for browser support, but the page is broken on "old" browsers anyway (`for..of` on `HTMLCollection`)
- Styles look similarly broken to the rest of the UI, so I didn't try to guess what the component should look like.