### PR TITLE
Change "Programming since.. " to "Joined at.."

### DIFF
--- a/web/templates/profile/profile.html.eex
+++ b/web/templates/profile/profile.html.eex
@@ -20,7 +20,7 @@
     </h2>
     <ul class="profile-detail-list">
       <li>
-        Programming since
+        Joined at
         <time datetime="<%= Calendar.Strftime.strftime!(@user.inserted_at, "%F") %>">
           <%= Calendar.Strftime.strftime!(@user.inserted_at, "%b %e, %Y") %></time>.
       </li>


### PR DESCRIPTION
I feel like "Programming since.." isnt really an accurate representation of what the date actually is. It would be fine if the first thing every programmer did was registring at Code::Stats(which would be awesome!) and counted every single char of code from then on. Needless to say, beginners usually end up on reading books and writing hello-worlds etc, so "Programming since.." is already doomed to be incorrect 99.99% of the time.